### PR TITLE
Remove superfluous print from EntityAPI.add_metadata

### DIFF
--- a/pyPreservica/entityAPI.py
+++ b/pyPreservica/entityAPI.py
@@ -1044,7 +1044,6 @@ class EntityAPI(AuthenticatedAPI):
         xml_request = xml.etree.ElementTree.tostring(xml_object, encoding='utf-8')
         end_point = f"/{entity.path}/{entity.reference}/metadata"
         logger.debug(xml_request)
-        print(xml_request)
         request = self.session.post(f'{self.protocol}://{self.server}/api/entity{end_point}', data=xml_request,
                                     headers=headers)
         if request.status_code == requests.codes.ok:
@@ -2648,3 +2647,4 @@ class EntityAPI(AuthenticatedAPI):
                                   "_delete_entity", request.content.decode('utf-8'))
         logger.error(exception)
         raise exception
+


### PR DESCRIPTION
A print statement was added to `add_metadata` when `add_metadata_as_fragment` was being introduced in commit 424df37.

Since this doesn't come with any user-friendly messaging and does not appear in `add_metadata_as_fragment` or `update_metadata`, I'm guessing this is a bit of temporary behaviour-inspection code that was accidentally committed.

As it introduces noise to scripts that use it, and the value is logged at DEBUG level if anyone wants it, I propose removing the print statement again.