### PR TITLE
Handling case where description is None

### DIFF
--- a/pyPreservica/retentionAPI.py
+++ b/pyPreservica/retentionAPI.py
@@ -87,8 +87,8 @@ class RetentionAPI(AuthenticatedAPI):
             assert ref == reference
             name = entity_response.find(f'.//{{{self.rm_ns}}}RetentionPolicy/{{{self.rm_ns}}}Name').text
             rp = RetentionPolicy(name, ref)
-            description = entity_response.find(f'.//{{{self.rm_ns}}}RetentionPolicy/{{{self.rm_ns}}}Description').text
-            rp.description = description
+            description = entity_response.find(f'.//{{{self.rm_ns}}}RetentionPolicy/{{{self.rm_ns}}}Description')
+            rp.description = description.text if description else ""
             security_tag = entity_response.find(f'.//{{{self.rm_ns}}}RetentionPolicy/{{{self.rm_ns}}}SecurityTag').text
             rp.security_tag = security_tag
             start_date_field = entity_response.find(


### PR DESCRIPTION
Hi again!

Bumped into an edge case that breaks if the retention policy description is None.  

I'm not sure if the other policy fields are required or not - it might be worth applying similar checks to the other fields. 

Let me know what you think!

Thanks